### PR TITLE
fix: WithRealmImport now adds the --import-realm flag to the commands

### DIFF
--- a/src/container/configuration.ts
+++ b/src/container/configuration.ts
@@ -32,6 +32,11 @@ export class Configuration {
 		return this;
 	}
 
+	public withRealmImport(): this {
+        this.commandsBuilder.withRealmImport();
+        return this;
+    }
+
 	public withDatabase(options: DatabaseOptions): this {
 		this.commandsBuilder.withDatabase(options);
 		return this;

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -32,6 +32,7 @@ export class KeycloakContainer extends GenericContainer {
 			source,
 			target: Keycloak.IMPORT_PATH
 		}]);
+		this.configuration.withRealmImport();
 		return this;
 	}
 


### PR DESCRIPTION
This fixes #151 
I just added a call to `configuration` for actually calling the `commandsBuilder` and appending the `--import-realm` flag.